### PR TITLE
extract: allow extracting existing directories and files

### DIFF
--- a/cpio/extract.go
+++ b/cpio/extract.go
@@ -78,7 +78,7 @@ func Extract(rs io.Reader, dest string) error {
 		case S_ISDIR:
 			log.Debug("unpacking dir")
 			m := os.FileMode(entry.Header.Mode()).Perm()
-			if err := os.Mkdir(target, m); err != nil {
+			if err := os.Mkdir(target, m); err != nil && !os.IsExist(err) {
 				return err
 			}
 		case S_ISFIFO:

--- a/cpio/extract_test.go
+++ b/cpio/extract_test.go
@@ -39,4 +39,14 @@ func TestExtract(t *testing.T) {
 	if err := Extract(f, tmpdir); err != nil {
 		t.Fatal(err)
 	}
+
+	log.Debugf("Test second extract on existing directory using destdir: %s", tmpdir)
+
+	if f, err = os.Open("../testdata/foo.cpio"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Extract(f, tmpdir); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This is the behavior of GNU cpio, at least when I tested it.
This also fixes the case when cpio file contains '.' as the
first entry; extract in that case would fail.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>