### PR TITLE
Collapse relative segments in archive path

### DIFF
--- a/cpio/extract.go
+++ b/cpio/extract.go
@@ -54,7 +54,7 @@ func Extract(rs io.Reader, dest string) error {
 			break
 		}
 
-		target := path.Join(dest, entry.Header.filename)
+		target := path.Join(dest, path.Clean(entry.Header.filename))
 		parent := path.Dir(target)
 
 		// Create the parent directory if it doesn't exist.


### PR DESCRIPTION
Runs `path.Clean` on the decoded archive filename as a defense against relative path segments that would otherwise allow a file to be written outside of the destination directory during extraction.

For comparison: In Gnu cpio this is done by the `cpio_safer_name_suffix` function.

Signed-off-by: J. Brandt Buckley <brandt@runlevel1.com>