### PR TITLE
Fix CPIO “bad magic” errors on short reads

### DIFF
--- a/cpio/cpio.go
+++ b/cpio/cpio.go
@@ -65,14 +65,8 @@ func (cs *CpioStream) ReadNextEntry() (*CpioEntry, error) {
 
 	// Read filename
 	buf := make([]byte, hdr.c_namesize)
-	n, err := cs.stream.Read(buf)
-	if err != nil {
+	if _, err = io.ReadFull(cs.stream, buf); err != nil {
 		return nil, err
-	}
-	if n != len(buf) {
-		log.Errorf("short read, got %d, expected %d", n, len(buf))
-		log.Debugf("namesize: %d", hdr.c_namesize)
-		return nil, fmt.Errorf("short read")
 	}
 
 	filename := string(buf[:len(buf)-1])
@@ -121,12 +115,9 @@ func (cr *countingReader) Seek(offset int64, whence int) (int64, error) {
 	}
 	log.Debugf("offset: %d, curr_pos: %d", offset, cr.curr_pos)
 	b := make([]byte, offset)
-	n, err := cr.Read(b)
+	n, err := io.ReadFull(cr, b)
 	if err != nil && err != io.EOF {
 		return 0, err
-	}
-	if int64(n) != offset {
-		return int64(n), fmt.Errorf("short seek")
 	}
 	return int64(n), nil
 }

--- a/cpio/extract_test.go
+++ b/cpio/extract_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"testing/iotest"
 )
 
 func TestExtract(t *testing.T) {
@@ -36,7 +37,8 @@ func TestExtract(t *testing.T) {
 	}
 	log.Debugf("using destdir: %s", tmpdir)
 
-	if err := Extract(f, tmpdir); err != nil {
+	hf := iotest.HalfReader(f)
+	if err := Extract(hf, tmpdir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -46,7 +48,8 @@ func TestExtract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Extract(f, tmpdir); err != nil {
+	hf = iotest.HalfReader(f)
+	if err := Extract(hf, tmpdir); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cpio/header.go
+++ b/cpio/header.go
@@ -75,7 +75,7 @@ func readHeader(r io.Reader) (*Cpio_newc_header, error) {
 	br := binaryReader{r: r}
 
 	magic := make([]byte, 6)
-	if _, err := r.Read(magic); err != nil {
+	if _, err := io.ReadFull(r, magic); err != nil {
 		return nil, err
 	}
 	if string(magic) != cpio_newc_magic {

--- a/cpio/header_test.go
+++ b/cpio/header_test.go
@@ -19,6 +19,7 @@ package cpio
 import (
 	"os"
 	"testing"
+	"testing/iotest"
 )
 
 func TestReadHeader(t *testing.T) {
@@ -27,7 +28,7 @@ func TestReadHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hdr, err := readHeader(f)
+	hdr, err := readHeader(iotest.HalfReader(f))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpmutils_test.go
+++ b/rpmutils_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"testing/iotest"
 )
 
 func TestReadHeader(t *testing.T) {
@@ -29,7 +30,7 @@ func TestReadHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hdr, err := ReadHeader(f)
+	hdr, err := ReadHeader(iotest.HalfReader(f))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestPayloadReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpm, err := ReadRpm(f)
+	rpm, err := ReadRpm(iotest.HalfReader(f))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +95,7 @@ func TestExpandPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpm, err := ReadRpm(f)
+	rpm, err := ReadRpm(iotest.HalfReader(f))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The existing code uses `Read(...)` on the incoming CPIO file reader to extract the first 6 magic bytes.  The code doesn't account for the possibility that read may return less than 6, which causes a "bad magic" error for valid files.

As a bonus, I went through the other tests and used `HalfReader` to validate and, in the future, prevent other partial read errors.