### PR TITLE
Fixed two minor errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go-rpmutils provides a few interfaces for handling RPM packages. There is a high
 
 ## Example
 ```go
-func Main() {
+func main() {
     f, err := os.Open("foo.rpm")
     if err != nil {
         panic(err)
@@ -46,7 +46,7 @@ func Main() {
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request
 
- 
+
 ## License
 
 go-rpmutils is released under the Apache 2.0 license. See [LICENSE](https://github.com/sassoftware/go-rpmutils/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ func main() {
     rpm := rpmutils.ReadRpm(f)
 
     // Get the name, epoch, version, release, and arch
-    nevra, err := rpm.GetNEVRA()
+    nevra, err := rpm.Header.GetNEVRA()
     if err != nil {
         panic(err)
     }


### PR DESCRIPTION
There were two minor errors in the example code in the README.md file.

Main() was changed into main() and the GetNEVRA() call is bound to the Header struct.
Now the example works for me.

Signed-off-by: Marcus Franke <marcus.franke@gmail.com>