### PR TITLE
Adding a stream -> stream signature method

### DIFF
--- a/log_test.go
+++ b/log_test.go
@@ -49,20 +49,20 @@ func TestLogFileLogging(t *testing.T) {
 	setupLogging(nil, buf, false, false)
 	logger.Info("foo")
 	if !strings.HasSuffix(string(buf.Bytes()), "foo\n") {
-		t.Fatal("wrong suffix: %s", string(buf.Bytes()))
+		t.Fatalf("wrong suffix: %s", string(buf.Bytes()))
 	}
 	buf.Reset()
 
 	logger.Debug("bar")
 	if string(buf.Bytes()) != "" {
-		t.Fatal("got wrong output: %s", string(buf.Bytes()))
+		t.Fatalf("got wrong output: %s", string(buf.Bytes()))
 	}
 	buf.Reset()
 
 	setupLogging(nil, buf, true, false)
 	logger.Debug("bar")
 	if !strings.HasSuffix(string(buf.Bytes()), "bar\n") {
-		t.Fatal("wrong suffix: %s", string(buf.Bytes()))
+		t.Fatalf("wrong suffix: %s", string(buf.Bytes()))
 	}
 }
 
@@ -76,7 +76,7 @@ func TestBothLogging(t *testing.T) {
 		t.Fatalf("got the wrong output: \"%s\"", string(buf1.Bytes()))
 	}
 	if !strings.HasSuffix(string(buf2.Bytes()), "foo\n") {
-		t.Fatal("wrong suffix: %s", string(buf2.Bytes()))
+		t.Fatalf("wrong suffix: %s", string(buf2.Bytes()))
 	}
 	buf1.Reset()
 	buf2.Reset()
@@ -86,7 +86,7 @@ func TestBothLogging(t *testing.T) {
 		t.Fatalf("got the wrong output: \"%s\"", string(buf1.Bytes()))
 	}
 	if string(buf2.Bytes()) != "" {
-		t.Fatal("got wrong output: %s", string(buf2.Bytes()))
+		t.Fatalf("got wrong output: %s", string(buf2.Bytes()))
 	}
 	buf1.Reset()
 	buf2.Reset()
@@ -97,6 +97,6 @@ func TestBothLogging(t *testing.T) {
 		t.Fatalf("got the wrong output: %s", string(buf1.Bytes()))
 	}
 	if !strings.HasSuffix(string(buf2.Bytes()), "bar\n") {
-		t.Fatal("wrong suffix: %s", string(buf2.Bytes()))
+		t.Fatalf("wrong suffix: %s", string(buf2.Bytes()))
 	}
 }

--- a/signatures.go
+++ b/signatures.go
@@ -169,6 +169,18 @@ func SignRpmFile(infile *os.File, outpath string, key *packet.PrivateKey, opts *
 	return header, rewriteRpm(infile, outpath, header)
 }
 
+// SignRpmFileIntoStream signs the rpmfile represented by infile with the
+// provided private key and sig options.  The entire signed RPM file is then
+// written to the outstream.
+func SignRpmFileIntoStream(outstream io.Writer, infile io.ReadSeeker, key *packet.PrivateKey, opts *SignatureOptions) error {
+	header, err := SignRpmStream(infile, key, opts)
+	if err != nil {
+		return err
+	}
+	delete(header.sigHeader.entries, SIG_RESERVEDSPACE-_SIGHEADER_TAG_BASE)
+	return writeRpm(infile, outstream, header.sigHeader)
+}
+
 func RewriteWithSignatures(infile *os.File, outpath string, sigPgp, sigRsa []byte) (*RpmHeader, error) {
 	header, err := ReadHeader(infile)
 	if err != nil {


### PR DESCRIPTION
It's very useful for library functions to not assume that clients are reading or writing to a filesystem.  This PR allows a client to read an RPM file from any source and then write it into any io.Writer compatible interface.

I also fixed the tests usage of `t.Fatal`