### PR TITLE
Header range accessor

### DIFF
--- a/rpmutils.go
+++ b/rpmutils.go
@@ -116,6 +116,20 @@ func readSignatureHeader(f io.Reader) ([]byte, *rpmHeader, error) {
 	return lead, hdr, err
 }
 
+type HeaderRange struct {
+	Start int
+	End   int
+}
+
+func (hdr *RpmHeader) GetRange() HeaderRange {
+	start := 96 + hdr.sigHeader.origSize
+	end := start + hdr.genHeader.origSize
+	return HeaderRange{
+		Start: start,
+		End:   end,
+	}
+}
+
 func (hdr *RpmHeader) HasTag(tag int) bool {
 	h, t := hdr.getHeader(tag)
 	return h.HasTag(t)

--- a/rpmutils_test.go
+++ b/rpmutils_test.go
@@ -44,8 +44,16 @@ func TestReadHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if nevra.Epoch != "0" || nevra.Name != "simple" || nevra.Version != "1.0.1" || nevra.Release != "1" || nevra.Arch != "i386" {
-		t.Fatalf("incorrect nevra: %s-%s:%s-%s.%s", nevra.Name, nevra.Epoch, nevra.Version, nevra.Release, nevra.Arch)
+	expectedNevra := NEVRA{
+		Epoch:   "0",
+		Name:    "simple",
+		Version: "1.0.1",
+		Release: "1",
+		Arch:    "i386",
+	}
+	if expectedNevra != *nevra {
+		t.Fatalf("incorrect nevra: %s (expected %s)",
+			nevra.String(), expectedNevra.String())
 	}
 
 	files, err := hdr.GetFiles()
@@ -55,6 +63,16 @@ func TestReadHeader(t *testing.T) {
 
 	if len(files) != 3 {
 		t.Fatalf("incorrect number of files %d", len(files))
+	}
+
+	hdrRange := hdr.GetRange()
+	expectedRange := HeaderRange{
+		Start: 280,
+		End:   1764,
+	}
+	if hdrRange != expectedRange {
+		t.Errorf("incorrect header range %+v (expected %+v)",
+			hdrRange, expectedRange)
 	}
 }
 


### PR DESCRIPTION
The goal of this commit is to provide and accessor to the header range
that provides the same value as in createrepo primary data file where :

<rpm:header-range start="1234" end="5678"/>

Signed-off-by: Laurent Stacul <laurent.stacul@gmail.com>