### PR TITLE
Add rpm to tar conversion

### DIFF
--- a/cpio/cpio.go
+++ b/cpio/cpio.go
@@ -28,7 +28,7 @@ var ErrStrippedHeader = errors.New("invalid cpio header: rpm-style stripped cpio
 
 type CpioEntry struct {
 	Header  *Cpio_newc_header
-	payload *file_stream
+	Payload *file_stream
 }
 
 type CpioStream struct {
@@ -93,7 +93,7 @@ func (cs *CpioStream) ReadNextEntry() (*CpioEntry, error) {
 	// Find the next entry
 	cs.next_pos = pad64(cs.stream.curr_pos + int64(hdr.c_filesize))
 
-	// Find the payload
+	// Find the Payload
 	payload, err := newFileStream(cs.stream, int64(hdr.c_filesize))
 	if err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func (cs *CpioStream) ReadNextEntry() (*CpioEntry, error) {
 	hdr.filename = filename
 	entry := CpioEntry{
 		Header:  hdr,
-		payload: payload,
+		Payload: payload,
 	}
 
 	return &entry, nil
@@ -122,7 +122,7 @@ func (cs *CpioStream) readStrippedEntry(hdr *Cpio_newc_header) (*CpioEntry, erro
 	if err != nil {
 		return nil, err
 	}
-	return &CpioEntry{Header: hdr, payload: payload}, nil
+	return &CpioEntry{Header: hdr, Payload: payload}, nil
 }
 
 func (cr *countingReader) Read(p []byte) (n int, err error) {

--- a/cpio/extract.go
+++ b/cpio/extract.go
@@ -93,7 +93,7 @@ func Extract(rs io.Reader, dest string) error {
 			}
 		case S_ISLNK:
 			buf := make([]byte, entry.Header.c_filesize)
-			if _, err := entry.payload.Read(buf); err != nil {
+			if _, err := entry.Payload.Read(buf); err != nil {
 				return err
 			}
 			if err := os.Symlink(string(buf), target); err != nil {
@@ -116,7 +116,7 @@ func Extract(rs io.Reader, dest string) error {
 			if err != nil {
 				return err
 			}
-			written, err := io.Copy(f, entry.payload)
+			written, err := io.Copy(f, entry.Payload)
 			if err != nil {
 				return err
 			}

--- a/cpio/reader.go
+++ b/cpio/reader.go
@@ -48,5 +48,5 @@ func (r *Reader) Next() (*Cpio_newc_header, error) {
 }
 
 func (r *Reader) Read(p []byte) (n int, err error) {
-	return r.cur_ent.payload.Read(p)
+	return r.cur_ent.Payload.Read(p)
 }

--- a/cpio/tar.go
+++ b/cpio/tar.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) SAS Institute, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cpio
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Extract the contents of a cpio stream from and writes it as a tar file into the provided writer
+func Tar(rs io.Reader, tarfile *tar.Writer) error {
+	hardLinks := map[int][]*tar.Header{}
+	inodes := map[int]string{}
+
+	stream := NewCpioStream(rs)
+
+	for {
+		entry, err := stream.ReadNextEntry()
+		if err != nil {
+			return err
+		}
+
+		if entry.Header.filename == TRAILER {
+			break
+		}
+
+		tarHeader := &tar.Header{
+			Name:     entry.Header.filename,
+			Size:     entry.Header.Filesize64(),
+			Mode:     int64(entry.Header.Mode()),
+			Uid:      entry.Header.Uid(),
+			Gid:      entry.Header.Gid(),
+			ModTime:  time.Unix(int64(entry.Header.Mtime()), 0),
+			Devmajor: int64(entry.Header.Devmajor()),
+			Devminor: int64(entry.Header.Devminor()),
+		}
+
+		var payload io.Reader
+		switch entry.Header.Mode() &^ 07777 {
+		case S_ISCHR:
+			tarHeader.Typeflag = tar.TypeChar
+		case S_ISBLK:
+			tarHeader.Typeflag = tar.TypeBlock
+		case S_ISDIR:
+			tarHeader.Typeflag = tar.TypeDir
+		case S_ISFIFO:
+			tarHeader.Typeflag = tar.TypeFifo
+		case S_ISLNK:
+			tarHeader.Typeflag = tar.TypeSymlink
+			buf := make([]byte, entry.Header.c_filesize)
+			if _, err := entry.payload.Read(buf); err != nil {
+				return err
+			}
+			tarHeader.Linkname = string(buf)
+		case S_ISREG:
+			if entry.Header.c_nlink > 1 && entry.Header.c_filesize == 0 {
+				tarHeader.Typeflag = tar.TypeLink
+				hardLinks[entry.Header.c_ino] = append(hardLinks[entry.Header.c_ino], tarHeader)
+				continue
+			}
+			tarHeader.Typeflag = tar.TypeReg
+			payload = entry.payload
+			inodes[entry.Header.c_ino] = entry.Header.filename
+		default:
+			return fmt.Errorf("unknown file mode 0%o for %s",
+				entry.Header.c_mode, entry.Header.filename)
+		}
+		if err := tarfile.WriteHeader(tarHeader); err != nil {
+			return fmt.Errorf("could not write tar header for %v: %v", tarHeader.Name, err)
+		}
+		if payload != nil {
+			written, err := io.Copy(tarfile, entry.payload)
+			if err != nil {
+				return fmt.Errorf("could not write body for %v: %v", tarHeader.Name, err)
+			}
+			if written != int64(entry.Header.c_filesize) {
+				return fmt.Errorf("short write body for %v", tarHeader.Name)
+			}
+		}
+	}
+	// write hardlinks
+	for node, links := range hardLinks {
+		target := inodes[node]
+		if target == "" {
+			return fmt.Errorf("no target file for inode %v found", node)
+		}
+		for _, tarHeader := range links {
+			tarHeader.Linkname = target
+			if err := tarfile.WriteHeader(tarHeader); err != nil {
+				return fmt.Errorf("could not write tar header for %v", tarHeader.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cpio/tar.go
+++ b/cpio/tar.go
@@ -64,7 +64,7 @@ func Tar(rs io.Reader, tarfile *tar.Writer) error {
 		case S_ISLNK:
 			tarHeader.Typeflag = tar.TypeSymlink
 			buf := make([]byte, entry.Header.c_filesize)
-			if _, err := entry.payload.Read(buf); err != nil {
+			if _, err := entry.Payload.Read(buf); err != nil {
 				return err
 			}
 			tarHeader.Linkname = string(buf)
@@ -75,7 +75,7 @@ func Tar(rs io.Reader, tarfile *tar.Writer) error {
 				continue
 			}
 			tarHeader.Typeflag = tar.TypeReg
-			payload = entry.payload
+			payload = entry.Payload
 			inodes[entry.Header.c_ino] = entry.Header.filename
 		default:
 			return fmt.Errorf("unknown file mode 0%o for %s",
@@ -85,7 +85,7 @@ func Tar(rs io.Reader, tarfile *tar.Writer) error {
 			return fmt.Errorf("could not write tar header for %v: %v", tarHeader.Name, err)
 		}
 		if payload != nil {
-			written, err := io.Copy(tarfile, entry.payload)
+			written, err := io.Copy(tarfile, entry.Payload)
 			if err != nil {
 				return fmt.Errorf("could not write body for %v: %v", tarHeader.Name, err)
 			}

--- a/cpio/tar_test.go
+++ b/cpio/tar_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) SAS Institute, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cpio
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTar(t *testing.T) {
+	f, err := os.Open("../testdata/foo.cpio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	tmpdir, err := ioutil.TempDir("", "cpio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	tarWriter, err := os.Create(filepath.Join(tmpdir, "test.tar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tarWriter.Close()
+	if err := Tar(f, tar.NewWriter(tarWriter)); err != nil {
+		t.Fatal(err)
+	}
+	tarWriter.Close()
+
+	tarReader, err := os.Open(filepath.Join(tmpdir, "test.tar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tarBall := tar.NewReader(tarReader)
+	headers := map[string]*tar.Header{
+		"./config": {Name: "./config", Size: 7, Mode: 33188},
+		"./dir":    {Name: "./dir", Size: 0, Mode: 16877},
+		"./normal": {Name: "./normal", Size: 7, Mode: 33188},
+	}
+	for {
+		header, err := tarBall.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				t.Fatal(err)
+			}
+		}
+		fmt.Println(header)
+		if headers[header.Name].Name != header.Name {
+			t.Fatal(fmt.Sprintf("Expected name %v, got %v", headers[header.Name].Name, header.Name))
+		}
+		if headers[header.Name].Size != header.Size {
+			t.Fatal(fmt.Sprintf("Expected size %v, got %v", headers[header.Name].Size, header.Size))
+		}
+		if headers[header.Name].Mode != header.Mode {
+			t.Fatal(fmt.Sprintf("Expected mode %v, got %v", headers[header.Name].Mode, header.Mode))
+		}
+		if headers[header.Name].Uid != header.Uid {
+			t.Fatal(fmt.Sprintf("Expected uid %v, got %v", headers[header.Name].Uid, header.Uid))
+		}
+		if headers[header.Name].Gid != header.Gid {
+			t.Fatal(fmt.Sprintf("Expected gid %v, got %v", headers[header.Name].Gid, header.Gid))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sassoftware/go-rpmutils
 go 1.12
 
 require (
+	github.com/klauspost/compress v1.11.1
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/klauspost/compress v1.11.1 h1:bPb7nMRdOZYDrpPMTA3EInUQrdgoBinqUuSwlGdKDdE=
+github.com/klauspost/compress v1.11.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/rpmutils.go
+++ b/rpmutils.go
@@ -64,6 +64,14 @@ func (rpm *Rpm) PayloadReader() (*cpio.Reader, error) {
 	return cpio.NewReader(pld), nil
 }
 
+func (rpm *Rpm) RawUncompressedRPMPayloadReader() (io.Reader, error) {
+	pld, err := uncompressRpmPayloadReader(rpm.f, rpm.Header)
+	if err != nil {
+		return nil, err
+	}
+	return pld, nil
+}
+
 func (rpm *Rpm) PayloadReaderExtended() (PayloadReader, error) {
 	pld, err := uncompressRpmPayloadReader(rpm.f, rpm.Header)
 	if err != nil {

--- a/uncompress.go
+++ b/uncompress.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/xi2/xz"
 )
 
@@ -63,6 +64,8 @@ func uncompressRpmPayloadReader(r io.Reader, hdr *RpmHeader) (io.Reader, error) 
 	}
 
 	switch compression {
+	case "zstd":
+		return zstd.NewReader(r)
 	case "gzip":
 		return gzip.NewReader(r)
 	case "bzip2":


### PR DESCRIPTION
Add a useful method to directly convert to tar files.

In my case I need this to convert RPMs to tar, so that [bazel](https://bazel.build/) can naively interpret RPM content as build input files.