### PR TITLE
add zstd compression support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sassoftware/go-rpmutils
 go 1.12
 
 require (
+	github.com/DataDog/zstd v1.4.5
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
+github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/uncompress.go
+++ b/uncompress.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/DataDog/zstd"
 	"github.com/xi2/xz"
 )
 
@@ -69,6 +70,8 @@ func uncompressRpmPayloadReader(r io.Reader, hdr *RpmHeader) (io.Reader, error) 
 		return bzip2.NewReader(r), nil
 	case "lzma", "xz":
 		return xz.NewReader(r, 0)
+	case "zstd":
+		return zstd.NewReader(r), nil
 	case "uncompressed":
 		return r, nil
 	default:


### PR DESCRIPTION
Was unable to extract a [fedora rpm](https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression) using this tool due to their move to zstd to compress the embedded cpio archive.

This change just adds the de-compressor for zstd.