### PR TITLE
Replace deprecated syscall package with sys.unix

### DIFF
--- a/fileutil/fileutil_unix.go
+++ b/fileutil/fileutil_unix.go
@@ -21,12 +21,12 @@ package fileutil
 
 import (
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 // HasLinks returns true if the given file has Nlink > 1
 func HasLinks(info os.FileInfo) bool {
-	stat, ok := info.Sys().(*syscall.Stat_t)
+	stat, ok := info.Sys().(*unix.Stat_t)
 	if !ok {
 		return false
 	}
@@ -35,5 +35,5 @@ func HasLinks(info os.FileInfo) bool {
 
 // Mkfifo creates a named pipe with the specified path and permissions
 func Mkfifo(path string, mode uint32) error {
-	return syscall.Mkfifo(path, mode)
+	return unix.Mkfifo(path, mode)
 }


### PR DESCRIPTION
Syscall package is deprecated and doesn't provide Mkfifo for illumos / Solaris based distributions. It's recommended to use the new implementation sys.unix as a replacement.

References:
- https://docs.google.com/document/d/1QXzI9I1pOfZPujQzxhyRy6EeHYTQitKKjHfpq0zpxZs
- https://go-review.googlesource.com/c/sys/+/14643/3/unix/syscall_solaris.go