### PR TITLE
chore: remove xi2/xz dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/klauspost/compress v1.17.8
 	github.com/stretchr/testify v1.9.0
 	github.com/ulikunitz/xz v0.5.12
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	go.uber.org/goleak v1.3.0
 	golang.org/x/sys v0.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/uncompress.go
+++ b/uncompress.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ulikunitz/xz"
 	"github.com/ulikunitz/xz/lzma"
-	"github.com/xi2/xz"
 )
 
 // Wrap RPM payload with uncompress reader, assumes that header has
@@ -77,7 +77,7 @@ func uncompressRpmPayloadReader(r io.Reader, hdr *RpmHeader) (io.Reader, error) 
 	case "lzma":
 		return lzma.NewReader(r)
 	case "xz":
-		return xz.NewReader(r, 0)
+		return xz.NewReader(r)
 	case "uncompressed":
 		// prevent ExpandPayload from closing the underlying file
 		return noCloseWrapper{r}, nil


### PR DESCRIPTION
This PR removes the dependency on `github.com/xi2/xz` because the same functionality exists in the already present `github.com/ulikunitz/xz`.

Compare:
- [xi2/xz.NewReader](https://github.com/xi2/xz/blob/48954b6210f8d154cb5f8484d3a3e1f83489309e/reader.go#L67)
- [ulikunitz/xz.NewReader](https://pkg.go.dev/github.com/ulikunitz/xz#NewReader)

Additionally, `github.com/xi2/xz` appears to be unmaintained as the latest commit was [7 years ago](https://github.com/xi2/xz/commits/master/).
